### PR TITLE
Fix mutation bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,16 +347,16 @@ cidrTools.overlap = (a, b) => {
   const aNets = uniq(Array.isArray(a) ? a : [a]);
   const bNets = uniq(Array.isArray(b) ? b : [b]);
 
-  for (let a of aNets) {
-    for (let b of bNets) {
-      a = parse(a);
-      b = parse(b);
+  for (const a of aNets) {
+    const aParsed = parse(a);
+    for (const b of bNets) {
+      const bParsed = parse(b);
 
-      if (a.address.v4 !== b.address.v4) {
+      if (aParsed.address.v4 !== bParsed.address.v4) {
         continue;
       }
 
-      if (overlap(a, b)) {
+      if (overlap(aParsed, bParsed)) {
         return true;
       }
     }

--- a/test.js
+++ b/test.js
@@ -40,6 +40,7 @@ async function main() {
   assert.deepStrictEqual(await m.overlap(["1.0.0.0", "2.0.0.0"], ["0.0.0.0/6"]), true);
   assert.deepStrictEqual(await m.overlap("::1", "0.0.0.1"), false);
   assert.deepStrictEqual(await m.overlap("fe80:1:0:0:0:0:0:0", "fe80::/10"), true);
+  assert.deepStrictEqual(await m.overlap("::1", ["0.0.0.1", "0.0.0.2"]), false);
   assert.deepStrictEqual(await m.normalize("0:0:0:0:0:0:0:0"), "::");
   assert.deepStrictEqual(await m.normalize("0:0:0:0:0:0:0:0/0"), "::/0");
 }


### PR DESCRIPTION
Mutating a from a string to a `IPCIDR` made the second parse fail if you had multiple entries in `bNets`. 

This patch fixes that by using different names and moving the first `parse` out of the inner loop. I also added a test case that fails without the patch.

Note that there might be more issues like this; I only am using this `overlap` and `exclude` so those are the only ones I've checked.