### PR TITLE
Reject out-of-range CIDR prefixes

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -390,6 +390,17 @@ test("parseCidr", () => {
   expect(() => parseCidr("/24")).toThrow();
   expect(() => parseCidr("1.2.3.4/")).toThrow();
   expect(() => parseCidr("::/")).toThrow();
+  // prefix out of range for the address family (0-32 for v4, 0-128 for v6)
+  expect(() => parseCidr("1.2.3.4/33")).toThrow();
+  expect(() => parseCidr("1.2.3.4/255")).toThrow();
+  expect(() => parseCidr("::/129")).toThrow();
+  expect(() => parseCidr("::/200")).toThrow();
+  // the other parse paths (normalizeCidr, containsCidr) must reject it too,
+  // rather than emitting "::undefined" or treating an IPv4 /33 as /32
+  expect(() => normalizeCidr("::/200")).toThrow();
+  expect(() => normalizeCidr("1.2.3.4/33")).toThrow();
+  expect(() => containsCidr("1.2.3.4/33", "1.2.3.4")).toThrow();
+  expect(() => containsCidr("::/129", "::1")).toThrow();
 });
 
 // readonly arrays must be accepted (compile-time guard against the type reverting to a mutable Array)

--- a/index.ts
+++ b/index.ts
@@ -96,6 +96,13 @@ function parsePrefixNum(str: string, slashIndex: number): number {
   return prefixNum;
 }
 
+// A prefix outside the valid range (0-32 for IPv4, 0-128 for IPv6) indexes the
+// prefix/mask lookup tables out of bounds, which silently treats an IPv4 /33 as
+// /32 or yields garbage like "::undefined". Reject it instead.
+function checkPrefix(prefixNum: number, maxBits: number, str: string): void {
+  if (prefixNum > maxBits) throw new Error(`Network is not a CIDR or IP: "${str}"`);
+}
+
 // Scratch output of parseIPv4Range, clobbered by its next call. Only rangeSlashIndex is valid
 // when it returns false.
 let rangeV4Start = 0;
@@ -137,6 +144,7 @@ function parseIPv4Range(str: string): boolean {
 
   const v4num = ((num << 8) | octet) >>> 0;
   rangeV4Prefix = rangeSlashIndex !== -1 ? parsePrefixNum(str, rangeSlashIndex) : 32;
+  checkPrefix(rangeV4Prefix, 32, str);
   const mask = hostMasks4[Math.max(32 - rangeV4Prefix, 0)];
   rangeV4Start = (v4num & ~mask) >>> 0;
   rangeV4End = (v4num | mask) >>> 0;
@@ -157,6 +165,7 @@ function doNormalize(cidr: Network, opts?: NormalizeOpts): Network {
   if (prefixNum === -1) {
     prefixNum = bits[version];
   }
+  checkPrefix(prefixNum, bits[version], cidr);
 
   if (version === 4) {
     const hostBits = 32 - prefixNum;
@@ -192,6 +201,7 @@ export function parseCidr(str: Network): ParsedCidr {
   const v4num = parseIPv4Fast(str, prefixPresent ? slashIndex : str.length);
   if (v4num !== -1) {
     const prefixNum = prefixPresent ? parsePrefixNum(str, slashIndex) : 32;
+    checkPrefix(prefixNum, 32, str);
     const ip = formatIPv4Fast(v4num);
     const mask = hostMasks4[Math.max(32 - prefixNum, 0)];
     return {
@@ -218,6 +228,7 @@ export function parseCidr(str: Network): ParsedCidr {
   if (prefixNum === -1) {
     prefixNum = numBits;
   }
+  checkPrefix(prefixNum, numBits, str);
 
   const prefix = prefixNumStrings[prefixNum] ?? String(prefixNum);
   const ip = stringifyIp({number, version, ipv4mapped, scopeid});
@@ -255,6 +266,7 @@ function parseCidrLeanSlow(str: Network): LeanParsedCidr {
   if (prefixNum === -1) {
     prefixNum = numBits;
   }
+  checkPrefix(prefixNum, numBits, str);
 
   const hostBits = numBits - prefixNum;
 


### PR DESCRIPTION
`parseCidr` and the functions built on it accept a prefix wider than the address family allows (over 32 for IPv4, over 128 for IPv6). The oversized prefix then indexes the internal prefix/mask lookup tables out of bounds, so the result is either a silently wrong network or literal garbage:

```js
normalizeCidr("::/200");                  // "::undefined"
normalizeCidr("2001:db8::/200");          // "2001:db8::undefined"
parseCidr("1.2.3.4/255").cidr;            // "1.2.3.4undefined"
normalizeCidr("1.2.3.4/33");              // "1.2.3.4/33"  (kept; the /33 is silently treated as /32)
containsCidr("1.2.3.4/33", "1.2.3.4");    // true, computed against a bogus /32
```

`/-1` and `/abc` already throw because the digit scan rejects them; only the too-large case slipped through.

The fix adds a small `checkPrefix` helper and calls it in each parse path once the version is known, so an out-of-range prefix throws the same `Network is not a CIDR or IP` error as the other malformed inputs. Valid prefixes, including the `/32` and `/128` boundaries and prefix-less inputs, are unaffected.

I extended the existing invalid-input test with the v4 and v6 out-of-range cases across `parseCidr`, `normalizeCidr` and `containsCidr`, since those reach the three separate parse paths. `make lint` and `make test` pass.
